### PR TITLE
Update README to correct self_signed_certificate usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ a self-signed certificate and install it in the
 In a recipe, you can write something like this:
 
 ```
-self_signed_certificate "www.example.com" do
+certbot_self_signed_certificate "www.example.com" do
 end
 
 template "/etc/nginx/sites-enabled/www.example.com.conf" do


### PR DESCRIPTION
I ran into an issue using the `self_signed_cerificate` provider as documented in the README. To get it working, I needed to add the cookbook name as a prefix. Thanks for your work on this cookbook!