### PR TITLE
Prevent 'incomplete chain' issue on newly activated certificate

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -26,7 +26,7 @@ action :create do
   cron "renew letsencrypt certificates" do
     time new_resource.frequency
     user 'root'
-    command "#{renew_command} && service nginx restart"
+    command "#{renew_command} --quiet --renew-hook \"/bin/systemctl reload nginx\""
     action :create
 
     only_if { new_resource.install_cron }

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -34,7 +34,7 @@ action :create do
 
   certbot_activate_certificate new_resource.domain do
     key_path certbot_privatekey_path_for(new_resource.domain)
-    cert_path certbot_cert_path_for(new_resource.domain)
+    cert_path certbot_fullchain_path_for(new_resource.domain)
   end
 end
 


### PR DESCRIPTION
I found that when using `certbot_certificate`, the fullchain symlink within `/etc/letsencrypt/current` was linked to `/etc/letsencrypt/live/<domain>/cert.pem` rather than `/etc/letsencrypt/live/<domain>/fullchain.pem`. This caused SSL Labs to report an incomplete chain, and limited the overall rating to "B" at best.

This updates the provider to link correctly to /etc/letsencrypt/live/<domain>/fullchain.pem. I've also updated the cron entry to use `--renew-hook` rather than chaining the nginx restart command to `certbot renew`